### PR TITLE
fail clippy for all warnings on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       uses: actions-rs/cargo@v1.0.1
       with:
         command: clippy
+        args: --all-targets -- -D warnings
 
   test:
     name: "Test"


### PR DESCRIPTION
…so we don't accidentally introduce new warnings