### PR TITLE
improve CLI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+db = ["run", "--bin", "db"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Once the database is running, it needs to be migrated so that the required
 tables get created etc.:
 
 ```bash
-cargo run --bin db migrate
+cargo db migrate
 ```
 
 ### Running the server
@@ -70,7 +70,7 @@ curl localhost:3000/tasks
 Migrate the test database:
 
 ```bash
-cargo run --bin db migrate -e test
+cargo db migrate -e test
 ```
 
 Then run the tests:


### PR DESCRIPTION
This simplifies the CLI by using Cargo `[alias]` so that instead of

```
cargo run --bin db migrate
```

one can now use:

```
cargo db migrate
```

closes #14 