### PR TITLE
Fix DB isolation for tests

### DIFF
--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -9,10 +9,12 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
 use std::env;
+use tokio_postgres::error::SqlState;
 use tokio_postgres::{config::Config, NoTls};
 use tower::ServiceExt;
 
-static TEMPLATE_LOCK: tokio::sync::Mutex<i32> = tokio::sync::Mutex::const_new(1);
+static DATABASE_TEMPLATE: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+static DATABASE_TEMPLATE_NAME: &str = "__test_template__";
 
 async fn prepare_db() -> Config {
     dotenvy::from_filename(".env.test").ok();
@@ -20,8 +22,77 @@ async fn prepare_db() -> Config {
     let config = Config::from_str(&db_url).unwrap();
     let db_name = config.get_dbname().unwrap();
 
-    let lock = TEMPLATE_LOCK.lock().await;
-    let (client, connection) = tokio_postgres::connect(&db_url, NoTls).await.unwrap();
+    DATABASE_TEMPLATE
+        .get_or_init(|| {
+            let db_url = db_url.clone();
+            async move {
+                // Create DB template
+                {
+                    let config = Config::from_str(&db_url).unwrap();
+                    let (client, connection) = config.connect(NoTls).await.unwrap();
+                    tokio::spawn(async move {
+                        if let Err(e) = connection.await {
+                            eprintln!("connection error: {}", e);
+                        }
+                    });
+
+                    if let Err(e) = client
+                        .execute(
+                            &format!(
+                                "create database {} template {}",
+                                DATABASE_TEMPLATE_NAME, db_name
+                            ),
+                            &[],
+                        )
+                        .await
+                    {
+                        if Some(&SqlState::DUPLICATE_DATABASE) != e.code() {
+                            client
+                                .execute(
+                                    &format!(
+                                        "alter database {} with is_template FALSE",
+                                        DATABASE_TEMPLATE_NAME
+                                    ),
+                                    &[],
+                                )
+                                .await
+                                .unwrap();
+                            client
+                                .execute(
+                                    &format!("drop database if exists {}", DATABASE_TEMPLATE_NAME),
+                                    &[],
+                                )
+                                .await
+                                .unwrap();
+                            client
+                                .execute(
+                                    &format!(
+                                        "create database {} template {}",
+                                        DATABASE_TEMPLATE_NAME, db_name
+                                    ),
+                                    &[],
+                                )
+                                .await
+                                .unwrap();
+                        }
+                    }
+
+                    client
+                        .execute(
+                            &format!(
+                                "alter database {} with is_template TRUE",
+                                DATABASE_TEMPLATE_NAME
+                            ),
+                            &[],
+                        )
+                        .await
+                        .unwrap();
+                }
+            }
+        })
+        .await;
+
+    let (client, connection) = config.connect(NoTls).await.unwrap();
     tokio::spawn(async move {
         if let Err(e) = connection.await {
             eprintln!("connection error: {}", e);
@@ -37,13 +108,14 @@ async fn prepare_db() -> Config {
 
     client
         .execute(
-            &format!("create database {} template {}", test_db_name, db_name),
+            &format!(
+                "create database {} template {}",
+                test_db_name, DATABASE_TEMPLATE_NAME
+            ),
             &[],
         )
         .await
         .unwrap();
-    drop(client);
-    drop(lock);
 
     let mut test_db_config = config.clone();
     test_db_config.dbname(&test_db_name);


### PR DESCRIPTION
This fixes isolation for test cases – essentially like what #17 does but it doesn't automatically run migrations but takes the "main" test db as it is.

closes #17 