### PR TITLE
simplify test helper

### DIFF
--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -14,12 +14,8 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
 use std::env;
-use tokio_postgres::error::SqlState;
 use tokio_postgres::{config::Config, NoTls};
 use tower::ServiceExt;
-
-static DATABASE_TEMPLATE: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
-static DATABASE_TEMPLATE_NAME: &str = "__test_template__";
 
 async fn prepare_db() -> Config {
     dotenvy::from_filename(".env.test").ok();
@@ -27,77 +23,9 @@ async fn prepare_db() -> Config {
     let config = Config::from_str(&db_url).unwrap();
     let db_name = config.get_dbname().unwrap();
 
-    DATABASE_TEMPLATE
-        .get_or_init(|| {
-            let db_url = db_url.clone();
-            async move {
-                // Create DB template
-                {
-                    let config = Config::from_str(&db_url).unwrap();
-                    let (client, connection) = config.connect(NoTls).await.unwrap();
-                    tokio::spawn(async move {
-                        if let Err(e) = connection.await {
-                            eprintln!("connection error: {}", e);
-                        }
-                    });
-
-                    if let Err(e) = client
-                        .execute(
-                            &format!(
-                                "create database {} template {}",
-                                DATABASE_TEMPLATE_NAME, db_name
-                            ),
-                            &[],
-                        )
-                        .await
-                    {
-                        if Some(&SqlState::DUPLICATE_DATABASE) != e.code() {
-                            client
-                                .execute(
-                                    &format!(
-                                        "alter database {} with is_template FALSE",
-                                        DATABASE_TEMPLATE_NAME
-                                    ),
-                                    &[],
-                                )
-                                .await
-                                .unwrap();
-                            client
-                                .execute(
-                                    &format!("drop database if exists {}", DATABASE_TEMPLATE_NAME),
-                                    &[],
-                                )
-                                .await
-                                .unwrap();
-                            client
-                                .execute(
-                                    &format!(
-                                        "create database {} template {}",
-                                        DATABASE_TEMPLATE_NAME, db_name
-                                    ),
-                                    &[],
-                                )
-                                .await
-                                .unwrap();
-                        }
-                    }
-
-                    client
-                        .execute(
-                            &format!(
-                                "alter database {} with is_template TRUE",
-                                DATABASE_TEMPLATE_NAME
-                            ),
-                            &[],
-                        )
-                        .await
-                        .unwrap();
-                }
-            }
-        })
-        .await;
-
-    let (client, connection) = config.connect(NoTls).await.unwrap();
+    let mut root_db_config = config.clone();
+    root_db_config.dbname("postgres");
+    let (client, connection) = root_db_config.connect(NoTls).await.unwrap();
     tokio::spawn(async move {
         if let Err(e) = connection.await {
             eprintln!("connection error: {}", e);
@@ -113,10 +41,7 @@ async fn prepare_db() -> Config {
 
     client
         .execute(
-            &format!(
-                "create database {} template {}",
-                test_db_name, DATABASE_TEMPLATE_NAME
-            ),
+            &format!("create database {} template {}", test_db_name, db_name),
             &[],
         )
         .await


### PR DESCRIPTION
This simplifies the test helper so that the additional template isn't needed anymore. The fix is to simply connect to the `postgres` database in the helper so no connection is ever made directly to the source database that's used as a template for all of the individual test databases. That also seems to be what e.g. Rails does in all of the DB management rake tasks (and what we do in [`db.rs`](https://github.com/marcoow/rust_rest/blob/main/src/bin/db.rs#L100) now.)