### PR TITLE
Allowing setting log level via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ cargo generate migration <migration-name>
 cargo run
 ```
 
+The log level can be set via the `RUST_LOG` env var (set one of `trace`,
+`debug`, `info` (default), `warn`, `error`), e.g.:
+
+```bash
+RUST_LOG=trace cargo run
+```
+
 ### Making requests with `curl`
 
 #### Creating a new task

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use axum::http::StatusCode;
+use dotenvy::dotenv;
 use std::net::SocketAddr;
 use tracing::{debug, Level};
 use tracing_panic::panic_hook;
@@ -15,6 +16,8 @@ mod test;
 
 #[tokio::main]
 async fn main() {
+    dotenv().ok();
+
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::TRACE)
         .finish();

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,3 @@
-use dotenvy::dotenv;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::env;
 
@@ -8,7 +7,6 @@ pub struct AppState {
 }
 
 pub async fn app_state() -> AppState {
-    dotenv().ok();
     let db_url = env::var("DATABASE_URL").expect("No DATABASE_URL set – cannot start server!");
 
     let db_pool = PgPoolOptions::new()


### PR DESCRIPTION
e.g.

```bash
RUST_LOG=trace cargo run
```

see #30 