### PR TITLE
use panic! in non-recoverable error cases

### DIFF
--- a/axum-on-rails/Cargo.lock
+++ b/axum-on-rails/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-panic",
  "tracing-subscriber",
  "url",
  "validator",
@@ -2376,6 +2377,16 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-panic"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf80030ce049691c9922d75be63cadf345110a245cd4581833c66f87c02ad25"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/axum-on-rails/src/util.rs
+++ b/axum-on-rails/src/util.rs
@@ -21,8 +21,7 @@ pub fn get_env() -> Environment {
             "prod" | "production" => Environment::Production,
             "test" => Environment::Test,
             unknown => {
-                eprintln!(r#"Unknown environment: "{}"!"#, unknown);
-                std::process::exit(1)
+                panic!(r#"Unknown environment: "{}"!"#, unknown);
             }
         },
         Err(_) => Environment::Development,
@@ -63,7 +62,7 @@ pub fn get_bind_addr() -> SocketAddr {
     };
 
     SocketAddr::from_str(format!("{}:{}", iface, port).as_str())
-        .expect(format!(r#"Could not parse bind addr "{}:{}"!"#, iface, port).as_str())
+        .unwrap_or_else(|_| panic!(r#"Could not parse bind addr "{}:{}"!"#, iface, port))
 }
 
 pub fn init_tracing() {


### PR DESCRIPTION
…so that the error is logged properly and the code gets cleaner since we're combining `process::exit` and logging

see #34