### PR TITLE
Consolidate config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,6 @@ name = "rust_rest_cli"
 version = "0.1.0"
 dependencies = [
  "axum-on-rails",
- "dotenvy",
  "rust_rest_config",
  "tokio",
 ]
@@ -1654,7 +1653,6 @@ dependencies = [
  "axum-on-rails",
  "axum-on-rails-procs",
  "clap",
- "dotenvy",
  "hyper",
  "rand",
  "refinery",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,8 @@ name = "rust_rest_cli"
 version = "0.1.0"
 dependencies = [
  "axum-on-rails",
+ "dotenvy",
+ "rust_rest_config",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "649f3e5d826594057e9a519626304d8da859ea8a0b18ce99500c586b8d45faee"
 dependencies = [
  "atomic",
+ "pear",
  "serde",
  "toml 0.8.8",
  "uncased",
@@ -954,6 +955,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "iri-string"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1262,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pear"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a386cd715229d399604b50d1361683fe687066f42d56f54be995bc6868f71c"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1588,6 +1631,7 @@ dependencies = [
 name = "rust_rest_config"
 version = "0.1.0"
 dependencies = [
+ "axum-on-rails",
  "serde",
 ]
 
@@ -2941,6 +2985,12 @@ checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zerocopy"

--- a/axum-on-rails/Cargo.lock
+++ b/axum-on-rails/Cargo.lock
@@ -543,6 +543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "649f3e5d826594057e9a519626304d8da859ea8a0b18ce99500c586b8d45faee"
 dependencies = [
  "atomic",
+ "pear",
  "serde",
  "toml 0.8.8",
  "uncased",
@@ -895,6 +896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "iri-string"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1191,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pear"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a386cd715229d399604b50d1361683fe687066f42d56f54be995bc6868f71c"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1377,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2775,6 +2818,12 @@ checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zerocopy"

--- a/axum-on-rails/Cargo.toml
+++ b/axum-on-rails/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 axum = "0.6"
 clap = "4.4"
 dotenvy = "0.15"
-figment = { version = "0.10", features = ["toml"] }
+figment = { version = "0.10", features = ["toml", "env"] }
 rand = "0.8"
 refinery = { version = "0.8", features = ["tokio-postgres"]}
 serde = { version = "1.0", features = ["derive"] } 

--- a/axum-on-rails/src/cli/env.rs
+++ b/axum-on-rails/src/cli/env.rs
@@ -1,10 +1,5 @@
+use crate::Environment;
 use clap::ArgMatches;
-
-#[derive(Debug)]
-pub enum Environment {
-    Development,
-    Test,
-}
 
 pub fn parse_env(sub_matches: &ArgMatches) -> Environment {
     let env = sub_matches

--- a/axum-on-rails/src/cli/env.rs
+++ b/axum-on-rails/src/cli/env.rs
@@ -9,6 +9,8 @@ pub fn parse_env(sub_matches: &ArgMatches) -> Environment {
 
     if env == "test" {
         Environment::Test
+    } else if env == "production" {
+        Environment::Production
     } else {
         Environment::Development
     }

--- a/axum-on-rails/src/cli/ui.rs
+++ b/axum-on-rails/src/cli/ui.rs
@@ -1,4 +1,4 @@
-use crate::cli::env::Environment;
+use crate::Environment;
 
 pub enum LogType {
     Info,
@@ -6,10 +6,17 @@ pub enum LogType {
     Error,
 }
 
-pub fn log_per_env(env: &Environment, log_type: LogType, dev_log: &str, test_log: &str) {
+pub fn log_per_env(
+    env: &Environment,
+    log_type: LogType,
+    dev_log: &str,
+    test_log: &str,
+    production_log: &str,
+) {
     match env {
         Environment::Development => log(log_type, dev_log),
         Environment::Test => log(log_type, test_log),
+        Environment::Production => log(log_type, production_log),
     }
 }
 

--- a/axum-on-rails/src/config.rs
+++ b/axum-on-rails/src/config.rs
@@ -10,6 +10,7 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {
+          // TODO: this should be 0.0.0.0 for production
           interface: String::from("127.0.0.1"),
           port: 3000,
         }

--- a/axum-on-rails/src/config.rs
+++ b/axum-on-rails/src/config.rs
@@ -7,6 +7,11 @@ pub struct ServerConfig {
   pub port: i32,
 }
 
+#[derive(Deserialize, Clone)]
+pub struct DatabaseConfig {
+  pub url: String,
+}
+
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {

--- a/axum-on-rails/src/config.rs
+++ b/axum-on-rails/src/config.rs
@@ -1,30 +1,36 @@
 use serde::Deserialize;
 use std::{net::SocketAddr, str::FromStr};
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct ServerConfig {
-  pub interface: String,
-  pub port: i32,
+    pub interface: String,
+    pub port: i32,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct DatabaseConfig {
-  pub url: String,
+    pub url: String,
 }
 
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {
-          // TODO: this should be 0.0.0.0 for production
-          interface: String::from("127.0.0.1"),
-          port: 3000,
+            // TODO: this should be 0.0.0.0 for production
+            interface: String::from("127.0.0.1"),
+            port: 3000,
         }
     }
 }
 
 impl ServerConfig {
-  pub fn get_bind_addr(&self) -> SocketAddr {
-      SocketAddr::from_str(format!("{}:{}", self.interface, self.port).as_str())
-          .unwrap_or_else(|_| panic!(r#"Could not parse bind addr "{}:{}"!"#, self.interface, self.port))
-  }
+    pub fn get_bind_addr(&self) -> SocketAddr {
+        SocketAddr::from_str(format!("{}:{}", self.interface, self.port).as_str()).unwrap_or_else(
+            |_| {
+                panic!(
+                    r#"Could not parse bind addr "{}:{}"!"#,
+                    self.interface, self.port
+                )
+            },
+        )
+    }
 }

--- a/axum-on-rails/src/config.rs
+++ b/axum-on-rails/src/config.rs
@@ -1,0 +1,24 @@
+use serde::Deserialize;
+use std::{net::SocketAddr, str::FromStr};
+
+#[derive(Deserialize, Clone)]
+pub struct ServerConfig {
+  pub interface: String,
+  pub port: i32,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        ServerConfig {
+          interface: String::from("127.0.0.1"),
+          port: 3000,
+        }
+    }
+}
+
+impl ServerConfig {
+  pub fn get_bind_addr(&self) -> SocketAddr {
+      SocketAddr::from_str(format!("{}:{}", self.interface, self.port).as_str())
+          .unwrap_or_else(|_| panic!(r#"Could not parse bind addr "{}:{}"!"#, self.interface, self.port))
+  }
+}

--- a/axum-on-rails/src/lib.rs
+++ b/axum-on-rails/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod cli;
 pub mod test;
+pub mod config;
 
 mod util;
 
-pub use util::get_bind_addr;
 pub use util::get_env;
 pub use util::init_tracing;
 pub use util::load_config;

--- a/axum-on-rails/src/lib.rs
+++ b/axum-on-rails/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod cli;
-pub mod test;
 pub mod config;
+pub mod test;
 
 mod util;
 

--- a/axum-on-rails/src/lib.rs
+++ b/axum-on-rails/src/lib.rs
@@ -7,4 +7,5 @@ mod util;
 pub use util::get_env;
 pub use util::init_tracing;
 pub use util::load_config;
+pub use util::load_config_for_env;
 pub use util::Environment;

--- a/axum-on-rails/src/test/helpers.rs
+++ b/axum-on-rails/src/test/helpers.rs
@@ -1,3 +1,4 @@
+use crate::config::DatabaseConfig;
 use axum::{
     body::Body,
     http::{Method, Request},
@@ -9,7 +10,6 @@ use rand::{thread_rng, Rng};
 use sqlx::postgres::{PgConnectOptions, PgConnection};
 use sqlx::{ConnectOptions, Connection, Executor, PgPool};
 use std::collections::HashMap;
-use std::env;
 use tower::ServiceExt;
 use url::Url;
 
@@ -31,14 +31,8 @@ pub fn build_test_context(
     }
 }
 
-pub async fn prepare_db() -> PgConnectOptions {
-    dotenvy::from_filename(".env.test").ok();
-    let db_url = Url::parse(
-        env::var("DATABASE_URL")
-            .expect("No DATABASE_URL set – cannot run tests!")
-            .as_str(),
-    )
-    .expect("Invalid DATABASE_URL!");
+pub async fn prepare_db(config: &DatabaseConfig) -> PgConnectOptions {
+    let db_url = Url::parse(&config.url).expect("Invalid DATABASE_URL!");
     let config: PgConnectOptions =
         ConnectOptions::from_url(&db_url).expect("Invalid DATABASE_URL!");
     let db_name = config.get_database().unwrap();

--- a/axum-on-rails/src/util.rs
+++ b/axum-on-rails/src/util.rs
@@ -1,10 +1,10 @@
 use figment::{
-    providers::{Format, Toml, Env},
+    providers::{Env, Format, Toml},
     Figment,
 };
 use serde::de::Deserialize;
-use std::fmt::{Display, Formatter, Result};
 use std::env;
+use std::fmt::{Display, Formatter, Result};
 use tracing::info;
 use tracing_panic::panic_hook;
 use tracing_subscriber::{filter::EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};

--- a/axum-on-rails/src/util.rs
+++ b/axum-on-rails/src/util.rs
@@ -1,3 +1,4 @@
+use dotenvy::dotenv;
 use figment::{
     providers::{Env, Format, Toml},
     Figment,
@@ -52,8 +53,26 @@ pub fn load_config<'a, T>() -> T
 where
     T: Deserialize<'a>,
 {
-    let environment = get_env();
-    let env_config_file = match environment {
+    let env = get_env();
+    load_config_for_env(&env)
+}
+
+pub fn load_config_for_env<'a, T>(env: &Environment) -> T
+where
+    T: Deserialize<'a>,
+{
+    match env {
+        Environment::Development => {
+            dotenv().ok();
+        }
+        Environment::Test => {
+            dotenvy::from_filename(".env.test").ok();
+        }
+        _ => { /* don't use any .env file for production */ }
+    }
+    dotenv().ok();
+
+    let env_config_file = match env {
         Environment::Development => "development.toml",
         Environment::Production => "production.toml",
         Environment::Test => "test.toml",

--- a/axum-on-rails/src/util.rs
+++ b/axum-on-rails/src/util.rs
@@ -1,10 +1,10 @@
 use figment::{
-    providers::{Format, Toml},
+    providers::{Format, Toml, Env},
     Figment,
 };
 use serde::de::Deserialize;
 use std::fmt::{Display, Formatter, Result};
-use std::{env, net::SocketAddr, str::FromStr};
+use std::env;
 use tracing::info;
 use tracing_panic::panic_hook;
 use tracing_subscriber::{filter::EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
@@ -65,24 +65,10 @@ where
             "config/environments/{}",
             env_config_file
         )))
+        .merge(Env::prefixed("SERVER_").map(|k| format!("server.{}", k.as_str()).into()))
         .extract()
         .expect("Could not read configuration!");
     config
-}
-
-pub fn get_bind_addr() -> SocketAddr {
-    // TODO: come up with a better name for the env var!
-    let iface = match env::var("APP_BIND_IFACE") {
-        Ok(val) => val,
-        Err(_) => String::from("127.0.0.1"),
-    };
-    let port = match env::var("APP_PORT") {
-        Ok(val) => val,
-        Err(_) => String::from("3000"),
-    };
-
-    SocketAddr::from_str(format!("{}:{}", iface, port).as_str())
-        .unwrap_or_else(|_| panic!(r#"Could not parse bind addr "{}:{}"!"#, iface, port))
 }
 
 pub fn init_tracing() {

--- a/axum-on-rails/src/util.rs
+++ b/axum-on-rails/src/util.rs
@@ -66,6 +66,7 @@ where
             env_config_file
         )))
         .merge(Env::prefixed("SERVER_").map(|k| format!("server.{}", k.as_str()).into()))
+        .merge(Env::prefixed("DATABASE_").map(|k| format!("database.{}", k.as_str()).into()))
         .extract()
         .expect("Could not read configuration!");
     config

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,5 @@ path = "src/bin/generate.rs"
 
 [dependencies]
 axum-on-rails = { path = "../axum-on-rails" }
-dotenvy = "0.15"
 rust_rest_config = { path = "../config" }
 tokio = { version = "1.33", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,4 +14,6 @@ path = "src/bin/generate.rs"
 
 [dependencies]
 axum-on-rails = { path = "../axum-on-rails" }
+dotenvy = "0.15"
+rust_rest_config = { path = "../config" }
 tokio = { version = "1.33", features = ["full"] }

--- a/cli/src/bin/db.rs
+++ b/cli/src/bin/db.rs
@@ -1,6 +1,8 @@
-use axum_on_rails::cli::db::cli;
+use axum_on_rails::{load_config, cli::db::cli};
+use crate::config::Config;
 
 #[tokio::main]
 async fn main() {
-    cli().await;
+    let config: Config = load_config();
+    cli(&config).await;
 }

--- a/cli/src/bin/db.rs
+++ b/cli/src/bin/db.rs
@@ -1,22 +1,10 @@
-use axum_on_rails::{cli::db::cli, load_config, Environment};
-use dotenvy::dotenv;
+use axum_on_rails::{cli::db::cli, load_config_for_env};
 use rust_rest_config::Config;
 
 #[tokio::main]
 async fn main() {
     cli(|env| {
-        match env {
-            Environment::Development => {
-                dotenv().ok();
-            }
-            Environment::Test => {
-                dotenvy::from_filename(".env.test").ok();
-            }
-            _ => { /* don't use any .env file for production */ }
-        }
-        dotenv().ok();
-
-        let config: Config = load_config();
+        let config: Config = load_config_for_env(&env);
         config.database
     })
     .await;

--- a/cli/src/bin/db.rs
+++ b/cli/src/bin/db.rs
@@ -12,7 +12,7 @@ async fn main() {
             Environment::Test => {
                 dotenvy::from_filename(".env.test").ok();
             }
-            _ => { /* don't use and .env file for production */ }
+            _ => { /* don't use any .env file for production */ }
         }
         dotenv().ok();
 

--- a/cli/src/bin/db.rs
+++ b/cli/src/bin/db.rs
@@ -1,8 +1,23 @@
-use axum_on_rails::{load_config, cli::db::cli};
-use crate::config::Config;
+use axum_on_rails::{cli::db::cli, load_config, Environment};
+use dotenvy::dotenv;
+use rust_rest_config::Config;
 
 #[tokio::main]
 async fn main() {
-    let config: Config = load_config();
-    cli(&config).await;
+    cli(|env| {
+        match env {
+            Environment::Development => {
+                dotenv().ok();
+            }
+            Environment::Test => {
+                dotenvy::from_filename(".env.test").ok();
+            }
+            _ => { /* don't use and .env file for production */ }
+        }
+        dotenv().ok();
+
+        let config: Config = load_config();
+        config.database
+    })
+    .await;
 }

--- a/cli/src/bin/generate.rs
+++ b/cli/src/bin/generate.rs
@@ -1,9 +1,6 @@
 use axum_on_rails::cli::generate::cli;
-use dotenvy::dotenv;
 
 #[tokio::main]
 async fn main() {
-    dotenv().ok();
-
     cli().await;
 }

--- a/cli/src/bin/generate.rs
+++ b/cli/src/bin/generate.rs
@@ -1,6 +1,9 @@
 use axum_on_rails::cli::generate::cli;
+use dotenvy::dotenv;
 
 #[tokio::main]
 async fn main() {
+    dotenv().ok();
+
     cli().await;
 }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
+axum-on-rails = { path = "../axum-on-rails" }
 serde = { version = "1.0", features = ["derive"] } 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,7 +1,7 @@
 use axum_on_rails::config::{DatabaseConfig, ServerConfig};
 use serde::Deserialize;
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct Config {
     #[serde(default)]
     pub server: ServerConfig,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,9 +1,10 @@
-use axum_on_rails::config::ServerConfig;
+use axum_on_rails::config::{DatabaseConfig, ServerConfig};
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
 pub struct Config {
     #[serde(default)]
     pub server: ServerConfig,
+    pub database: DatabaseConfig,
     // add your config settings here…
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,6 +1,9 @@
+use axum_on_rails::config::ServerConfig;
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
 pub struct Config {
+    #[serde(default)]
+    pub server: ServerConfig,
     // add your config settings here…
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -9,7 +9,6 @@ anyhow = "1.0"
 axum = "0.6"
 axum-on-rails = { path = "../axum-on-rails" }
 clap = "4.4"
-dotenvy = "0.15"
 rand = "0.8"
 refinery = { version = "0.8", features = ["tokio-postgres"]}
 rust_rest_config = { path = "../config" }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,6 +1,5 @@
 use axum::http::StatusCode;
 use axum_on_rails::{init_tracing, load_config};
-use dotenvy::dotenv;
 use tracing::info;
 
 mod controllers;
@@ -14,8 +13,6 @@ use rust_rest_config::Config;
 mod test;
 
 pub async fn run() -> anyhow::Result<()> {
-    dotenv().ok();
-
     let config: Config = load_config();
 
     let app_state = state::app_state(config.clone()).await;

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,5 +1,5 @@
 use axum::http::StatusCode;
-use axum_on_rails::{get_bind_addr, init_tracing, load_config};
+use axum_on_rails::{init_tracing, load_config};
 use dotenvy::dotenv;
 use tracing::info;
 
@@ -8,18 +8,20 @@ mod middlewares;
 mod routes;
 mod state;
 
+use rust_rest_config::Config;
+
 #[cfg(test)]
 mod test;
 
 pub async fn run() -> anyhow::Result<()> {
     dotenv().ok();
 
-    let config: rust_rest_config::Config = load_config();
+    let config: Config = load_config();
 
-    let app_state = state::app_state(config).await;
+    let app_state = state::app_state(config.clone()).await;
     let app = routes::routes(app_state);
 
-    let addr = get_bind_addr();
+    let addr = config.server.get_bind_addr();
     info!("Listening on {}", addr);
     axum::Server::bind(&addr)
         .serve(app.into_make_service())

--- a/web/src/state.rs
+++ b/web/src/state.rs
@@ -1,6 +1,5 @@
 use rust_rest_config::Config;
 use sqlx::postgres::{PgPool, PgPoolOptions};
-use std::env;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -9,10 +8,8 @@ pub struct AppState {
 }
 
 pub async fn app_state(config: Config) -> AppState {
-    let db_url = env::var("DATABASE_URL").expect("No DATABASE_URL set – cannot start server!");
-
     let db_pool = PgPoolOptions::new()
-        .connect(db_url.as_str())
+        .connect(config.database.url.as_str())
         .await
         .expect("Could not connect to database!");
 

--- a/web/src/test/helpers.rs
+++ b/web/src/test/helpers.rs
@@ -1,14 +1,19 @@
 use crate::routes::routes;
 use crate::state::AppState;
 use axum_on_rails::{
-    load_config,
+    load_config_for_env,
     test::helpers::{build_test_context, prepare_db, TestContext},
+    Environment,
 };
 use rust_rest_config::Config;
 use sqlx::postgres::PgPoolOptions;
 
+static CONFIG: tokio::sync::OnceCell<Config> = tokio::sync::OnceCell::const_new();
+
 pub async fn setup() -> TestContext {
-    let config: Config = load_config();
+    let config: &Config = CONFIG
+        .get_or_init(|| async { load_config_for_env::<Config>(&Environment::Test) })
+        .await;
 
     let db_config = prepare_db(&config.database).await;
     let db_pool = PgPoolOptions::new()
@@ -18,7 +23,7 @@ pub async fn setup() -> TestContext {
 
     let app = routes(AppState {
         db_pool: db_pool.clone(),
-        config,
+        config: config.clone(),
     });
 
     build_test_context(app, db_pool, db_config)

--- a/web/src/test/helpers.rs
+++ b/web/src/test/helpers.rs
@@ -1,10 +1,10 @@
-use crate::config::Config;
 use crate::routes::routes;
 use crate::state::AppState;
 use axum_on_rails::{
     load_config,
     test::helpers::{build_test_context, prepare_db, TestContext},
 };
+use rust_rest_config::Config;
 use sqlx::postgres::PgPoolOptions;
 
 pub async fn setup() -> TestContext {

--- a/web/src/test/helpers.rs
+++ b/web/src/test/helpers.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::routes::routes;
 use crate::state::AppState;
 use axum_on_rails::{
@@ -7,9 +8,11 @@ use axum_on_rails::{
 use sqlx::postgres::PgPoolOptions;
 
 pub async fn setup() -> TestContext {
-    let config = load_config();
+    dotenvy::from_filename(".env.test").ok();
 
-    let db_config = prepare_db().await;
+    let config: Config = load_config();
+
+    let db_config = prepare_db(&config.database).await;
     let db_pool = PgPoolOptions::new()
         .connect_with(db_config.clone())
         .await

--- a/web/src/test/helpers.rs
+++ b/web/src/test/helpers.rs
@@ -8,8 +8,6 @@ use rust_rest_config::Config;
 use sqlx::postgres::PgPoolOptions;
 
 pub async fn setup() -> TestContext {
-    dotenvy::from_filename(".env.test").ok();
-
     let config: Config = load_config();
 
     let db_config = prepare_db(&config.database).await;


### PR DESCRIPTION
This fixes a few things around config handling:

* all configuration is now kept in the `Config` struct that has fields `server: ServerConfig` and `database: DatabaseConfig` by default which keep server (e.g. bind addr) and database (e.g. connection url) settings.
* the CLIs now receive a closure for getting the configuration as in the case of the CLIs the environment is only known once the CLI arguments have been parsed since the env is passed as e.g. `-e test` (as opposed to e.g. as an env var)
* the configuration to be used for testing is now only loaded once overall as opposed to once for every test case
* the redundant `Environment` enum that was only used for CLI commands has been removed
* the CLI commands now also handle a production environment
* the `seed` CLI command now also accepts an env argument

see #34 